### PR TITLE
Various polishing

### DIFF
--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -91,7 +91,7 @@ class DarkFramePreprocessor:
         prompt us to take a new one.
     limit: integer or None, optional
         Number of dark frames to cache. If None, do not limit.
-    stream_name : string, optional
+    stream_name: string, optional
         Event stream name for dark frames. Default is 'dark'.
     """
     def __init__(self, *, dark_plan, max_age,
@@ -112,9 +112,20 @@ class DarkFramePreprocessor:
 
     @property
     def cache(self):
+        """
+        A read-only view of the cached dark frames.
+        """
         return self._cache
 
     def add_snapshot(self, snapshot, state=None):
+        """
+        Add a darkframe.
+
+        Parameters
+        ----------
+        snapshot: SnapshotDevice
+        state: dict, optional
+        """
         logger.debug("Captured snapshot for state %r", state)
         state = state or {}
         self._evict_old_entries()
@@ -131,6 +142,13 @@ class DarkFramePreprocessor:
                 del self._cache[key]
 
     def get_snapshot(self, state):
+        """
+        Access a darkframe.
+
+        Parameters
+        ----------
+        state: dict
+        """
         self._evict_old_entries()
         key = frozendict(state)
         try:
@@ -144,6 +162,9 @@ class DarkFramePreprocessor:
             return snapshot
 
     def clear(self):
+        """
+        Clear all cached darkframes.
+        """
         self._cache.clear()
 
     def __call__(self, plan):

--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -110,6 +110,10 @@ class DarkFramePreprocessor:
         # Map state to (creation_time, snapshot).
         self._cache = collections.OrderedDict()
 
+    @property
+    def cache(self):
+        return self._cache
+
     def add_snapshot(self, snapshot, state=None):
         logger.debug("Captured snapshot for state %r", state)
         state = state or {}

--- a/bluesky_darkframes/tests/tests.py
+++ b/bluesky_darkframes/tests/tests.py
@@ -46,17 +46,16 @@ def test_max_age(RE):
     """
     Test the a dark frame is reused until it expires, and then re-taken.
     """
-    # This tests an internal detail.
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
         dark_plan=dark_plan, max_age=1)
     RE.preprocessors.append(dark_frame_preprocessor)
     # The first executation adds something to the cache.
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 1
-    state, = dark_frame_preprocessor._cache
+    assert len(dark_frame_preprocessor.cache) == 1
+    state, = dark_frame_preprocessor.cache
     # A second execution reuses the cache entry, adds nothing.
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 1
+    assert len(dark_frame_preprocessor.cache) == 1
     dark_frame_preprocessor.get_snapshot(state)
     # Wait for it to age out.
     time.sleep(1.01)
@@ -70,21 +69,20 @@ def test_locked_signals(RE):
     if the locked signal goes back to the original value, the original dark
     frame is reused.
     """
-    # This tests an internal detail.
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
         dark_plan=dark_plan, max_age=100,
         locked_signals=[det.exposure_time])
     RE.preprocessors.append(dark_frame_preprocessor)
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 1
+    assert len(dark_frame_preprocessor.cache) == 1
     RE(bps.mv(det.exposure_time, 0.02))
     # This should take a new dark frame.
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 2
+    assert len(dark_frame_preprocessor.cache) == 2
     # This should reuse the first one.
     RE(bps.mv(det.exposure_time, 0.01))
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 2
+    assert len(dark_frame_preprocessor.cache) == 2
 
 
 def test_limit(RE):
@@ -93,27 +91,26 @@ def test_limit(RE):
     if the locked signal goes back to the original value, the original dark
     frame is reused.
     """
-    # This tests an internal detail.
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
         dark_plan=dark_plan, max_age=100,
         locked_signals=[det.exposure_time],
         limit=1)
     RE.preprocessors.append(dark_frame_preprocessor)
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 1
-    state, = dark_frame_preprocessor._cache
+    assert len(dark_frame_preprocessor.cache) == 1
+    state, = dark_frame_preprocessor.cache
     previous_state = state
     RE(bps.mv(det.exposure_time, 0.02))
     # This should take a new dark frame and evict the last one.
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 1
-    state, = dark_frame_preprocessor._cache
+    assert len(dark_frame_preprocessor.cache) == 1
+    state, = dark_frame_preprocessor.cache
     assert state != previous_state
     previous_state = state
     # This should take a new dark frame and evict the last one.
     RE(bps.mv(det.exposure_time, 0.01))
     RE(count([img]))
-    assert len(dark_frame_preprocessor._cache) == 1
-    state, = dark_frame_preprocessor._cache
+    assert len(dark_frame_preprocessor.cache) == 1
+    state, = dark_frame_preprocessor.cache
     assert state != previous_state
     previous_state = state

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -3,7 +3,7 @@ Reference
 =========
 
 .. autoclass:: bluesky_darkframes.DarkFramePreprocessor
-   :members: add_snapshot, get_snapshot, __call__
+   :members: clear, cache, add_snapshot, get_snapshot, __call__
 
 .. autoclass:: bluesky_darkframes.SnapshotDevice
 


### PR DESCRIPTION
* Raise a more informative exception if no 'dark' frame has been received for a
  'light frame.
* Make all exceptions inherit from a `BlueskyDarkframeException` base.
* Expose `DarkFramePreprocessor.cache` as a public property for debugging.
* Add unit tests for streaming export, and test the path that raises an
  exception.