### PR TITLE
Check before 'trigger' not after 'save'.

### DIFF
--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -15,7 +15,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 
-logger = logging.getLogger('bluesky_darkframe')
+logger = logging.getLogger('bluesky.darkframes')
 
 
 class SnapshotDevice(Device):

--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -98,6 +98,7 @@ class DarkFramePreprocessor:
     ----------
     dark_plan: callable
         Expected siganture: ``dark_plan() -> snapshot_device``
+    detector : Device
     max_age: float
         Time after which a fresh dark frame should be acquired
     locked_signals: Iterable, optional
@@ -108,9 +109,10 @@ class DarkFramePreprocessor:
     stream_name: string, optional
         Event stream name for dark frames. Default is 'dark'.
     """
-    def __init__(self, *, dark_plan, max_age,
+    def __init__(self, *, dark_plan, detector, max_age,
                  locked_signals=None, limit=None, stream_name='dark'):
         self.dark_plan = dark_plan
+        self.detector = detector
         self.max_age = max_age
         # The signals have to have unique names for this to work.
         names = [signal.name for signal in locked_signals or ()]
@@ -126,6 +128,7 @@ class DarkFramePreprocessor:
         self._current_snapshot = _SnapshotShell()
         self._current_state = None
         self._force_read_before_next_event = True
+        self._latch = False
 
     @property
     def cache(self):
@@ -205,22 +208,26 @@ class DarkFramePreprocessor:
             try:
                 snapshot = self.get_snapshot(state)
             except NoMatchingSnapshot:
+                logger.info(f"Taking a new dark frame for state=%r", state)
                 snapshot = yield from self.dark_plan()
                 self.add_snapshot(snapshot, state)
             if snapshot_changed or force_read:
+                logger.info(f"Creating a 'dark' Event for state=%r", state)
                 self._current_snapshot.set_snaphsot(snapshot)
                 # Read the Snapshot into the 'dark' Event stream.
                 yield from bps.stage(self._current_snapshot)
                 yield from bps.trigger_and_read([self._current_snapshot],
                                                 name=self.stream_name)
                 yield from bps.unstage(self._current_snapshot)
+            self._latch = False
             if msg is not None:
                 return (yield msg)
 
         def maybe_insert_dark_frame(msg):
-            if msg.command == 'create':
+            if msg.command == 'trigger' and msg.obj is self.detector and not self._latch:
                 force_read = self._force_read_before_next_event
                 self._force_read_before_next_event = False
+                self._latch = True
                 return insert_dark_frame(force_read=force_read, msg=msg), None
             elif msg.command == 'open_run':
                 self._force_read_before_next_event = True

--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -325,7 +325,7 @@ class DarkSubtraction(event_model.DocumentRouter):
             self.dark_frame, = doc['data'][self.field]
             self.dark_frame -= self.pedestal
             numpy.clip(self.dark_frame, a_min=0, a_max=None, out=self.dark_frame)
-        if doc['descriptor'] == self.light_descriptor:
+        elif doc['descriptor'] == self.light_descriptor:
             if self.dark_frame is None:
                 raise NoDarkFrame(
                     "DarkSubtraction has not received a 'dark' Event yet, so "

--- a/bluesky_darkframes/tests/tests.py
+++ b/bluesky_darkframes/tests/tests.py
@@ -28,7 +28,7 @@ def dark_plan():
 
 def test_one_dark_event_emitted(RE):
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-        dark_plan=dark_plan, max_age=3)
+        dark_plan=dark_plan, detector=det, max_age=3)
     RE.preprocessors.append(dark_frame_preprocessor)
 
     def verify_one_dark_frame(name, doc):
@@ -41,7 +41,7 @@ def test_one_dark_event_emitted(RE):
 
 def test_mid_scan_dark_frames(RE):
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-        dark_plan=dark_plan, max_age=0)
+        dark_plan=dark_plan, detector=det, max_age=0)
     RE.preprocessors.append(dark_frame_preprocessor)
 
     def verify_four_dark_frames(name, doc):
@@ -56,7 +56,7 @@ def test_max_age(RE):
     Test the a dark frame is reused until it expires, and then re-taken.
     """
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-        dark_plan=dark_plan, max_age=1)
+        dark_plan=dark_plan, detector=det, max_age=1)
     RE.preprocessors.append(dark_frame_preprocessor)
     # The first executation adds something to the cache.
     RE(count([det]))
@@ -79,7 +79,7 @@ def test_locked_signals(RE):
     frame is reused.
     """
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-        dark_plan=dark_plan, max_age=100,
+        dark_plan=dark_plan, detector=det, max_age=100,
         locked_signals=[det.exposure_time])
     RE.preprocessors.append(dark_frame_preprocessor)
     RE(count([det]))
@@ -101,7 +101,7 @@ def test_limit(RE):
     frame is reused.
     """
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-        dark_plan=dark_plan, max_age=100,
+        dark_plan=dark_plan, detector=det, max_age=100,
         locked_signals=[det.exposure_time],
         limit=1)
     RE.preprocessors.append(dark_frame_preprocessor)
@@ -159,7 +159,7 @@ def test_streaming_export(RE, tmp_path, pedestal):
     RE.subscribe(rr)
 
     dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-        dark_plan=dark_plan, max_age=100)
+        dark_plan=dark_plan, detector=det, max_age=100)
     RE.preprocessors.append(dark_frame_preprocessor)
 
     RE(count([det]))

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -41,13 +41,9 @@ for whether/how dark frames can be reused.)
 
    def dark_plan():
        yield from bps.mv(shutter, 'closed')
-       yield from bps.unstage(det)
-       yield from bps.stage(det)
        yield from bps.trigger(det, group='darkframe-trigger')
        yield from bps.wait('darkframe-trigger')
        snapshot = bluesky_darkframes.SnapshotDevice(det)
-       yield from bps.unstage(det)
-       yield from bps.stage(det)
        yield from bps.mv(shutter, 'open')
        return snapshot
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -67,24 +67,25 @@ Here we set the rules for when to take fresh dark frames, (2). Examples:
 
    # Always take a fresh dark frame at the beginning of each run.
    dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-       dark_plan=dark_plan, max_age=0)
+       dark_plan=dark_plan, detector=det, max_age=0)
 
    # Take a dark frame if the last one we took is more than 30 seconds old.
    dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-       dark_plan=dark_plan, max_age=30)
+       dark_plan=dark_plan, detector=det, max_age=30)
 
    # Take a fresh dark frame if the last one we took *with this exposure time*
    # is more than 30 seconds old.
    dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-       dark_plan=dark_plan, max_age=30, locked_signals=[det.exposure_time])
+       dark_plan=dark_plan, detector=det, max_age=30,
+       locked_signals=[det.exposure_time])
 
    # Always take a new dark frame if the exposure time was changed from the
    # previous run, even if we took one with this exposure time on some earlier
    # run. Also, re-take if the settings haven't changed but the last dark
    # frame is older than 30 seconds.
    dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-       dark_plan=dark_plan, max_age=30, locked_signals=[det.exposure_time],
-       limit=1)
+       dark_plan=dark_plan, detector=det, max_age=30,
+       locked_signals=[det.exposure_time], limit=1)
 
 We'll pick one example and configure the RunEngine to apply it to all plans.
 This means that any plan, including user-defined ones, will automatically have
@@ -93,7 +94,7 @@ dark frames included.
 .. jupyter-execute::
 
    dark_frame_preprocessor = bluesky_darkframes.DarkFramePreprocessor(
-       dark_plan=dark_plan, max_age=30)
+       dark_plan=dark_plan, detector=det, max_age=30)
    RE.preprocessors.append(dark_frame_preprocessor)
 
 Acquire and Access Data


### PR DESCRIPTION
Currently, the preprocessor checks whether a new dark frame is needed *after*
each Event is emitted. Consider this sequence:

* Event
* Change exposure.
* Event

The preprocessor won't see the new exposure setting until *after* the Event
goes out.

This PR changes the preprocessor to make it check just before ~opening each Event~ triggering a new acquisition from the detector of interest.