### PR TITLE
Clean up on `RE.abort()`

### DIFF
--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -143,6 +143,25 @@ class _SnapshotShell:
     def get_snapshot(self):
         return self.__snapshot
 
+    def describe(self):
+        return self.__snapshot.describe()
+
+    def describe_configuration(self):
+        return self.__snapshot.describe_configuration()
+
+    def read(self):
+        return self.__snapshot.read()
+
+    def read_configuration(self):
+        return self.__snapshot.read_configuration()
+
+    def trigger(self):
+        return self.__snapshot.trigger()
+
+    @property
+    def name(self):
+        return self.__snapshot.name
+
     def __getattr__(self, key):
         return getattr(self.__snapshot, key)
 

--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -378,6 +378,9 @@ class DarkFramePreprocessor:
                 # new Run.
                 self._force_read_before_next_event = True
                 return None, None
+            elif msg.command == "close_run" and msg.kwargs["exit_status"] in ("abort", "halt"):
+                self._latch = False
+                return None, None
             else:
                 return None, None
 

--- a/bluesky_darkframes/__init__.py
+++ b/bluesky_darkframes/__init__.py
@@ -308,6 +308,8 @@ class DarkFramePreprocessor:
         or whether it can use a cached reading.
         """
 
+        self._latch = False
+
         if self._disabled:
             logger.info("%r is disabled, will act as a no-op", self)
             return (yield from plan)
@@ -377,9 +379,6 @@ class DarkFramePreprocessor:
                 # Make sure we get a new Event because we have just started a
                 # new Run.
                 self._force_read_before_next_event = True
-                return None, None
-            elif msg.command == "close_run" and msg.kwargs["exit_status"] in ("abort", "halt"):
-                self._latch = False
                 return None, None
             else:
                 return None, None

--- a/bluesky_darkframes/sim.py
+++ b/bluesky_darkframes/sim.py
@@ -67,7 +67,12 @@ class DiffractionDetector(Device):
 
         self._path_stem = None
         self._stashed_image_reading = None
-        self._stashed_image_data_key = None
+        self._stashed_image_data_key = {
+            "source": "SIM:image",
+            "shape": [200, 200],
+            "dtype": "array",
+            "external": "FILESTORE",
+        }
 
     def stage(self):
         file_stem = short_uid()
@@ -99,12 +104,6 @@ class DiffractionDetector(Device):
         datum = {"resource": self._resource_uid, "datum_kwargs": dict(index=data_counter), "datum_id": datum_id}
         self._asset_docs_cache.append(("datum", datum))
         self._stashed_image_reading = {"value": datum_id, "timestamp": time.time()}
-        self._stashed_image_data_key = {
-            "source": "SIM:image",
-            "shape": image.shape,
-            "dtype": "array",
-            "external": "FILESTORE",
-        }
         return TimerStatus(self, self.exposure_time.get())
 
     def read(self):


### PR DESCRIPTION
We need to reset the `self._latch` to `False` on a previously aborted run to be able to use the preprocessor without restarting `bsui` (the issue was reported by the NSLS-II QAS staff: https://jira.nsls2.bnl.gov/browse/HXSS-516).
