### PR TITLE
DOC: release notes for v0.6.0

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,6 +1,7 @@
-# This workflow will upload a Python Package using flit when a release is
-# created.  For more information see:
-# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflows will upload a Python Package when a release is created.
+# For more information see:
+# - https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+# - https://github.com/pypa/gh-action-pypi-publish
 
 name: PyPI upload
 
@@ -12,28 +13,27 @@ jobs:
   publish_pypi:
     name: Publish package to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install wheel twine setuptools
+      - name: Build package
+        run: |
+          set -vxeuo pipefail
+          python -m pip install --upgrade pip
+          pip install wheel setuptools
+          python setup.py sdist bdist_wheel
 
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        # The PYPI_PASSWORD must be a pypi token with the "pypi-" prefix with sufficient permissions to upload this package
-        # https://pypi.org/help/#apitoken
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - name: Publish wheels to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./dist/

--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,5 @@ target/
 .ipynb_checkpoints
 
 # Output from executed examples in sphinx
-docs/exported_files/*
-docs/live_exported_files/*
+exported_files/*
+live_exported_files/*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -207,6 +207,8 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
+    "event_model": ("https://blueskyproject.io/event-model/main/", None),
+    "suitcase.tiff_series": ("https://blueskyproject.io/suitcase", None),
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,21 @@
 Release History
 ===============
 
+v0.6.0 (2023-06-15)
+-------------------
+
+Fixed
++++++
+* clean up on ``RE.abort()`` properly
+* support for read-only arrays from databroker
+* fix versioneer compatibility with Python 3.11
+
+Changed
+++++++++
+* rerender the project's structure with new cookiecutter.
+* improve tests
+
+
 v0.5.0 (2021-10-08)
 -------------------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -36,11 +36,12 @@ This direct solution is best one for some circumstances. However, if you find
 yourself looking at the prospect of rewriting a large number of plans just to
 add this dark frame logic, it may be simpler to use a bluesky *preprocessor*. A
 preprocessor can augment or modify the steps in a plan. The
-:class:`DarkFramePreprocessor` watches for a given detector to be triggered and
-inserts steps in the plan to acquire and/or record a dark frame when needed.
-Depending on how you configure it, it can reuse a given dark frame multiple
-times. Thus, it will not necessarily *acquire* a dark frame for every Run, but
-it will ensure that at least one 'dark' Event is *recorded* in every Run.
+:class:`~bluesky_darkframes.DarkFramePreprocessor` watches for a given detector
+to be triggered and inserts steps in the plan to acquire and/or record a dark
+frame when needed.  Depending on how you configure it, it can reuse a given dark
+frame multiple times. Thus, it will not necessarily *acquire* a dark frame for
+every Run, but it will ensure that at least one 'dark' Event is *recorded* in
+every Run.
 
 The preprocessor can be applied to specific plans, using Python's decorator
 syntax
@@ -91,7 +92,7 @@ We need to know:
 
 To address (1) define a bluesky plan that closes the shutter, takes an
 acquistion, and reopens the shutter. The last two lines in this example use a
-special mechanism, :class:`bluesky_darkframes.SnapshotDevice`, to stash the
+special mechanism, :class:`~bluesky_darkframes.SnapshotDevice`, to stash the
 acquisition where it can potentially be reused. (Later on we'll set the rules
 for whether/how dark frames can be reused.)
 
@@ -235,7 +236,7 @@ original if desired.
    !ls exported_files
 
 To customize the file name and other output options, see
-:class:`suitcase.tiff_series.Serializer`.
+:class:`~suitcase.tiff_series.Serializer`.
 
 Export data during acquisition (streaming)
 ------------------------------------------


### PR DESCRIPTION
The notes are based on the auto-generated notes for the upcoming release:

---

## What's Changed
* Make test pickier just to be safe. by @danielballan in https://github.com/bluesky/bluesky-darkframes/pull/26
* Fix versioneer compat with py311 by @tacaswell in https://github.com/bluesky/bluesky-darkframes/pull/34
* Rerender with new cookiecutter by @mrakitin in https://github.com/bluesky/bluesky-darkframes/pull/36
* Clean up on `RE.abort()` by @mrakitin in https://github.com/bluesky/bluesky-darkframes/pull/37
* FIX: in current data broker this array can comeback read-only by @tacaswell in https://github.com/bluesky/bluesky-darkframes/pull/30

## New Contributors
* @mrakitin made their first contribution in https://github.com/bluesky/bluesky-darkframes/pull/36

**Full Changelog**: https://github.com/bluesky/bluesky-darkframes/compare/v0.5.0...v0.6.0